### PR TITLE
extend Ember.Service to avoid deprecation warning

### DIFF
--- a/addon/models.js
+++ b/addon/models.js
@@ -8,7 +8,7 @@ function owner(x) {
   return Ember.getOwner ? Ember.getOwner(x) : x.container;
 }
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   make: function(nameOrClass, properties = {}) {
     var modelClass = nameOrClass;
     if (Ember.typeOf(nameOrClass) !== "class") {
@@ -105,4 +105,3 @@ export default Ember.Object.extend({
     return t.serialize(value);
   }
 });
-


### PR DESCRIPTION
Specifically the `ember-application.validate-type` deprecation, which wasn't happy about registering an Ember.Object as `service:flexureModels`.
